### PR TITLE
fixing implicit any's

### DIFF
--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -48,7 +48,7 @@ module wx {
         has(key: T): boolean;
         delete(key: T): boolean;
         clear(): void;
-        forEach(callback: (T) => void, thisArg?): void;
+        forEach(callback: (item: T) => void, thisArg?: any): void;
         size: number;
         isEmulated: boolean;
     }
@@ -252,7 +252,7 @@ module wx {
         /* @param refreshTrigger {Rx.Observable<TDontCare>} When this Observable is signalled, the derived collection will be manually reordered/refiltered.
         **/
         project<TNew, TDontCare>(filter?: (item: T) => boolean, orderer?: (a: TNew, b: TNew) => number, 
-            selector?: (T) => TNew, refreshTrigger?: Rx.Observable<TDontCare>, scheduler?: Rx.IScheduler): IObservableReadOnlyList<TNew>;
+            selector?: (item: T) => TNew, refreshTrigger?: Rx.Observable<TDontCare>, scheduler?: Rx.IScheduler): IObservableReadOnlyList<TNew>;
         /**        
         /* Creates a live-projection of itself that can be filtered, re-ordered and mapped.
         /* @param filter {(item: T) => boolean} A filter to determine whether to exclude items in the derived collection
@@ -300,7 +300,7 @@ module wx {
     **/
     export interface IObservableList<T> extends IObservableReadOnlyList<T> {
         isEmpty: IObservableProperty<boolean>;
-        set(index: number, item: T);
+        set(index: number, item: T): any;
 
         add(item: T): void;
         push(item: T): void;
@@ -312,7 +312,7 @@ module wx {
         removeAt(index: number): void;
         addRange(collection: Array<T>): void;
         insertRange(index: number, collection: Array<T>): void;
-        move(oldIndex, newIndex): void;
+        move(oldIndex: any, newIndex: any): void;
         removeAll(items: Array<T>): void;
         removeRange(index: number, count: number): void;
         reset(): void;
@@ -434,7 +434,7 @@ module wx {
 
         literal?: boolean;
         constant?: boolean;
-        assign?: (self, value, locals) => any;
+        assign?: (self: any, value: any, locals: any) => any;
     }
 
     export interface ICompiledExpressionRuntimeHooks {
@@ -448,7 +448,7 @@ module wx {
         compileExpression(src: string, options?: IExpressionCompilerOptions, cache?: { [exp: string]: ICompiledExpression }): ICompiledExpression;
         getRuntimeHooks(locals: any): ICompiledExpressionRuntimeHooks;
         setRuntimeHooks(locals: any, hooks: ICompiledExpressionRuntimeHooks): void;
-        parseObjectLiteral(objectLiteralString): Array<IObjectLiteralToken>;
+        parseObjectLiteral(objectLiteralString: any): Array<IObjectLiteralToken>;
     }
 
     export interface IAnimation {
@@ -531,7 +531,7 @@ module wx {
         * Removes any binding-related state from the specified node. Use with care! In most cases you would want to use cleanNode!
         * @param {Node} node The node to clear
         **/
-        clearNodeState(node: Node);
+        clearNodeState(node: Node): any;
 
         /**
         * Compiles a simple string expression or multiple expressions within an object-literal recursively into an expression tree
@@ -556,7 +556,7 @@ module wx {
         * @param {Node} node The node for which the data-context gets assembled
         * @param {IDataContext} ctx The current data-context
         **/
-        registerDataContextExtension(extension:(node: Node, ctx:IDataContext)=> void);
+        registerDataContextExtension(extension:(node: Node, ctx:IDataContext)=> void): any;
 
         /**
         * Evaluates an expression against a data-context and returns the result
@@ -709,7 +709,7 @@ module wx {
     }
 
     export interface IRoute {
-        parse(url): Object;
+        parse(url: any): Object;
         stringify(params?: Object): string;
         concat(route: IRoute): IRoute;
         isAbsolute: boolean;
@@ -851,7 +851,7 @@ module wx {
         * missing and no extras.
         * @param {string} state Absolute state path.
         **/
-        is(state: string, params?: any, options?: any);
+        is(state: string, params?: any, options?: any): any;
 
         /**
         * A method to determine if the current active state is equal to or is the child of the state stateName. 
@@ -859,7 +859,7 @@ module wx {
         * to be passed, just the ones you'd like to test for equality.
         * @param {string} state Absolute state path.
         **/
-        includes(state: string, params?: any, options?: any);
+        includes(state: string, params?: any, options?: any): any;
 
         /**
         * Resets internal state configuration to defaults (for unit-testing)
@@ -1079,10 +1079,10 @@ module wx {
         data?: any;
         headers?: Object;
         raw?: boolean;  // do not deserialize response text
-        dump?: (any)=> string;
-        load?: (string)=> Object;
+        dump?: (value: any)=> string;
+        load?: (text: string)=> Object;
         xmlHttpRequest?: ()=> XMLHttpRequest;
-        promise?: (fn)=> Promise<any>;
+        promise?: (executor: (resolve: (value?: any | PromiseLike<any>) => void, reject: (reason?: any) => void) => void)=> Promise<any>;
     }
     
     export interface IHttpClient {

--- a/src/web.rx.d.ts
+++ b/src/web.rx.d.ts
@@ -33,7 +33,7 @@ declare module wx {
         has(key: T): boolean;
         delete(key: T): boolean;
         clear(): void;
-        forEach(callback: (T) => void, thisArg?: any): void;
+        forEach(callback: (item: T) => void, thisArg?: any): void;
         size: number;
         isEmulated: boolean;
     }
@@ -215,7 +215,7 @@ declare module wx {
         /* @param refreshTrigger {Rx.Observable<TDontCare>} When this Observable is signalled, the derived collection will be manually reordered/refiltered.
         **/
         project<TNew, TDontCare>(filter?: (item: T) => boolean, orderer?: (a: TNew, b: TNew) => number, 
-            selector?: (T) => TNew, refreshTrigger?: Rx.Observable<TDontCare>, scheduler?: Rx.IScheduler): IObservableReadOnlyList<TNew>;
+            selector?: (item: T) => TNew, refreshTrigger?: Rx.Observable<TDontCare>, scheduler?: Rx.IScheduler): IObservableReadOnlyList<TNew>;
         /**        
         /* Creates a live-projection of itself that can be filtered, re-ordered and mapped.
         /* @param filter {(item: T) => boolean} A filter to determine whether to exclude items in the derived collection
@@ -382,7 +382,7 @@ declare module wx {
         (scope?: any, locals?: any): any;
         literal?: boolean;
         constant?: boolean;
-        assign?: (self, value, locals) => any;
+        assign?: (self: any, value: any, locals: any) => any;
     }
     interface ICompiledExpressionRuntimeHooks {
         readFieldHook?: (o: any, field: any) => any;
@@ -1246,7 +1246,7 @@ declare module wx {
     /* @param {any} thisArg Object to use as this when executing the executeAsync
     /* @return {Command<any>} A Command whose ExecuteAsync just returns the CommandParameter immediately. Which you should ignore!
     **/
-    function command(execute: (any) => void, canExecute?: Rx.Observable<boolean>, scheduler?: Rx.IScheduler, thisArg?: any): ICommand<any>;
+    function command(execute: (param: any) => void, canExecute?: Rx.Observable<boolean>, scheduler?: Rx.IScheduler, thisArg?: any): ICommand<any>;
     /**        
     /* Creates a default Command that has a synchronous action.
     /* @param {(any) => void} execute The action to executed when the command gets invoked
@@ -1254,14 +1254,14 @@ declare module wx {
     /* @param {any} thisArg Object to use as this when executing the executeAsync
     /* @return {Command<any>} A Command whose ExecuteAsync just returns the CommandParameter immediately. Which you should ignore!
     **/
-    function command(execute: (any) => void, canExecute?: Rx.Observable<boolean>, thisArg?: any): ICommand<any>;
+    function command(execute: (param: any) => void, canExecute?: Rx.Observable<boolean>, thisArg?: any): ICommand<any>;
     /**        
     /* Creates a default Command that has a synchronous action.
     /* @param {(any) => void} execute The action to executed when the command gets invoked
     /* @param {any} thisArg Object to use as this when executing the executeAsync
     /* @return {Command<any>} A Command whose ExecuteAsync just returns the CommandParameter immediately. Which you should ignore!
     **/
-    function command(execute: (any) => void, thisArg?: any): ICommand<any>;
+    function command(execute: (param: any) => void, thisArg?: any): ICommand<any>;
     /**        
     /* Creates a default Command that has no background action.
     /* @param {Rx.Observable<boolean>} canExecute An Observable that determines when the Command can Execute. WhenAny is a great way to create this!
@@ -1278,7 +1278,7 @@ declare module wx {
     /* @param {any} thisArg Object to use as this when executing the executeAsync
     /* @return {Command<T>} A Command which returns all items that are created via calling executeAsync as a single stream.
     **/
-    function asyncCommand<T>(canExecute: Rx.Observable<boolean>, executeAsync: (any) => Rx.Observable<T>, scheduler?: Rx.IScheduler, thisArg?: any): ICommand<T>;
+    function asyncCommand<T>(canExecute: Rx.Observable<boolean>, executeAsync: (param: any) => Rx.Observable<T>, scheduler?: Rx.IScheduler, thisArg?: any): ICommand<T>;
     /**        
     /* Creates a Command typed to the given executeAsync Observable method. Use this method if your background method returns Rx.IObservable
     /* @param {(any) => Rx.Observable<T>} executeAsync Method to call that creates an Observable representing an operation to execute in the background. The Command's canExecute will be false until this Observable completes. If this Observable terminates with OnError, the Exception is marshaled to ThrownExceptions
@@ -1286,7 +1286,7 @@ declare module wx {
     /* @param {any} thisArg Object to use as this when executing the executeAsync
     /* @return {Command<T>} A Command which returns all items that are created via calling executeAsync as a single stream.
     **/
-    function asyncCommand<T>(canExecute: Rx.Observable<boolean>, executeAsync: (any) => Rx.Observable<T>, thisArg?: any): ICommand<T>;
+    function asyncCommand<T>(canExecute: Rx.Observable<boolean>, executeAsync: (param: any) => Rx.Observable<T>, thisArg?: any): ICommand<T>;
     /**        
     /* Creates a Command typed to the given executeAsync Observable method. Use this method if your background method returns Rx.IObservable
     /* @param {(any) => Rx.Observable<T>} executeAsync Method to call that creates an Observable representing an operation to execute in the background. The Command's canExecute will be false until this Observable completes. If this Observable terminates with OnError, the Exception is marshaled to ThrownExceptions
@@ -1294,14 +1294,14 @@ declare module wx {
     /* @param {any} thisArg Object to use as this when executing the executeAsync
     /* @return {Command<T>} A Command which returns all items that are created via calling executeAsync as a single stream.
     **/
-    function asyncCommand<T>(executeAsync: (any) => Rx.Observable<T>, scheduler?: Rx.IScheduler, thisArg?: any): ICommand<T>;
+    function asyncCommand<T>(executeAsync: (param: any) => Rx.Observable<T>, scheduler?: Rx.IScheduler, thisArg?: any): ICommand<T>;
     /**        
     /* Creates a Command typed to the given executeAsync Observable method. Use this method if your background method returns Rx.IObservable
     /* @param {(any) => Rx.Observable<T>} executeAsync Method to call that creates an Observable representing an operation to execute in the background. The Command's canExecute will be false until this Observable completes. If this Observable terminates with OnError, the Exception is marshaled to ThrownExceptions
     /* @param {any} thisArg Object to use as this when executing the executeAsync
     /* @return {Command<T>} A Command which returns all items that are created via calling executeAsync as a single stream.
     **/
-    function asyncCommand<T>(executeAsync: (any) => Rx.Observable<T>, thisArg?: any): ICommand<T>;
+    function asyncCommand<T>(executeAsync: (param: any) => Rx.Observable<T>, thisArg?: any): ICommand<T>;
     /**        
     /* This creates a Command that calls several child Commands when invoked. Its canExecute will match the combined result of the child canExecutes (i.e. if any child commands cannot execute, neither can the parent)
     /* @param {(any) => Rx.Observable<T>} commands The commands to combine
@@ -1443,10 +1443,10 @@ declare module wx {
         data?: any;
         headers?: Object;
         raw?: boolean;  // do not deserialize response text
-        dump?: (any)=> string;
-        load?: (string)=> Object;
+        dump?: (value: any)=> string;
+        load?: (text: string)=> Object;
         xmlHttpRequest?: ()=> XMLHttpRequest;
-        promise?: (fn)=> Rx.IPromise<any>;
+        promise?: (fn: Function)=> Rx.IPromise<any>;
     }
     
     export interface IHttpClient {

--- a/src/web.rx.d.ts
+++ b/src/web.rx.d.ts
@@ -1446,7 +1446,7 @@ declare module wx {
         dump?: (value: any)=> string;
         load?: (text: string)=> Object;
         xmlHttpRequest?: ()=> XMLHttpRequest;
-        promise?: (fn: Function)=> Rx.IPromise<any>;
+        promise?: (executor: (resolve: (value?: any | PromiseLike<any>) => void, reject: (reason?: any) => void) => void)=> Rx.IPromise<any>;
     }
     
     export interface IHttpClient {


### PR DESCRIPTION
This PR will fix any errors that show up due to implicit any's (if you have that turned on in `tsconfig.json`). Not too much to explain here, I took a guess at appropriate param names and types when it wasn't obvious. The param names don't really matter at all they are just placeholders anyways.

The ambiguous types are found in
* `ICompiledExpression.assign`
* `IHttpClientOptions.promise`

probably best to make sure i guessed correctly for those.

There is another related PR coming that appends to this one that also trims the (many) trailing whitespaces in this file. Only one needs to be accepted.