### PR TITLE
adding the invokeCommand operation as an extension on any observable

### DIFF
--- a/src/RxExtensions.d.ts
+++ b/src/RxExtensions.d.ts
@@ -7,6 +7,8 @@ declare module Rx {
         continueWith(action: () => void): Observable<any>;
         continueWith<TResult>(action: (T) => TResult): Observable<TResult>;
         continueWith<TOther>(obs: Rx.Observable<TOther>): Observable<TOther>;
+
+        invokeCommand<TResult>(command: wx.ICommand<TResult>): Rx.IDisposable;
     }
 
     export interface ObservableStatic {


### PR DESCRIPTION
Not much to explain for this one. This function is really handy if you want to invoke a command as a part of a chained observable sequence.

```ts
// live search 
let sub = this.searchText.changed
  .debounce(100)
  .distinctUntilChanged()
  .invokeCommand(this.search)
```

***NOTE***: this produces a subscription to the observable sequence and therefore a disposable. This means that you may want to *cleanup* the `sub` at some point.

this PR relates to #11 