### PR TITLE
adding functionality to reset a list with an array of new contents

### DIFF
--- a/src/Collections/List.ts
+++ b/src/Collections/List.ts
@@ -307,8 +307,15 @@ export class ObservableList<T> implements wx.IObservableList<T>, Rx.IDisposable,
         return this.inner;
     }
 
-    public reset(): void {
+    public reset(contents?: Array<T>): void {
+        if (contents == null) {
         this.publishResetNotification();
+        } else {
+            let suppress = this.suppressChangeNotifications();
+            this.clear();
+            this.addRange(contents);
+            suppress.dispose();
+        }
     }
 
     public add(item: T): void {

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -315,7 +315,7 @@ module wx {
         move(oldIndex, newIndex): void;
         removeAll(items: Array<T>): void;
         removeRange(index: number, count: number): void;
-        reset(): void;
+        reset(contents?: Array<T>): void;
 
         sort(comparison: (a: T, b: T) => number): void;
         forEach(callbackfn: (value: T, index: number, array: T[]) => void, thisArg?: any): void;

--- a/src/web.rx.d.ts
+++ b/src/web.rx.d.ts
@@ -277,7 +277,7 @@ declare module wx {
         move(oldIndex: any, newIndex: any): void;
         removeAll(items: Array<T>): void;
         removeRange(index: number, count: number): void;
-        reset(): void;
+        reset(contents?: Array<T>): void;
         sort(comparison: (a: T, b: T) => number): void;
         forEach(callbackfn: (value: T, index: number, array: T[]) => void, thisArg?: any): void;
         map<U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): U[];


### PR DESCRIPTION
This PR allows you to essentially replace the contents of a list with an entirely new set of contents and produce a single change (reset) notification afterwards. This is a simplification of calling `suppressChangeNotifications -> clear -> addRange -> dispose`

this PR resolves #15 

I'm not sure if reset is an appropriate host for this functionality (it seems like a natural fit but you may have a better idea).