### PR TITLE
Selector based remove

### DIFF
--- a/src/Collections/List.ts
+++ b/src/Collections/List.ts
@@ -251,10 +251,11 @@ export class ObservableList<T> implements wx.IObservableList<T>, Rx.IDisposable,
         });
     }
 
-    public removeAll(items: T[]): void {
-        if (items == null) {
+    public removeAll(itemsOrSelector: T[] | ((item: T) => boolean)): T[] {
+        if (itemsOrSelector == null) {
             throwError("items");
         }
+        const items: T[] = Array.isArray(itemsOrSelector) ? itemsOrSelector : this.inner.filter(itemsOrSelector);
 
         let disp = this.isLengthAboveResetThreshold(items.length) ?
             this.suppressChangeNotifications() : Rx.Disposable.empty;
@@ -264,6 +265,7 @@ export class ObservableList<T> implements wx.IObservableList<T>, Rx.IDisposable,
             // accounting of the length
             items.forEach(x => this.remove(x));
         });
+        return items;
     }
 
     public removeRange(index: number, count: number): void {
@@ -331,17 +333,13 @@ export class ObservableList<T> implements wx.IObservableList<T>, Rx.IDisposable,
         return this.inner.indexOf(item) !== -1;
     }
 
-    public remove(itemOrSelector: T | ((item: T) => boolean)): boolean {
-        const selector =<(item: T) => boolean> ((typeof itemOrSelector === "function") ? itemOrSelector : item => item === itemOrSelector);
-        let itemsRemoved = false;
-        for (let index = 0; index < this.inner.length; index++) {
-            if (selector(this.inner[index])) {
-                itemsRemoved = true;
-                this.removeItem(index);
-                index--;
-            }
-        }
-        return itemsRemoved;
+    public remove(item: T): boolean {
+        let index = this.inner.indexOf(item);
+        if (index === -1)
+            return false;
+
+        this.removeItem(index);
+        return true;
     }
 
     public indexOf(item: T): number {
@@ -784,8 +782,9 @@ class ObservableListProjection<T, TValue> extends ObservableList<TValue> impleme
         throwError(this.readonlyExceptionMessage);
     }
 
-    public removeAll(items: TValue[]): void {
+    public removeAll(itemsOrSelector: TValue[] | ((item: TValue) => boolean)): TValue[] {
         throwError(this.readonlyExceptionMessage);
+        return undefined;
     }
 
     public removeRange(index: number, count: number): void {
@@ -800,7 +799,7 @@ class ObservableListProjection<T, TValue> extends ObservableList<TValue> impleme
         throwError(this.readonlyExceptionMessage);
     }
 
-    public remove(itemOrSelector: TValue | ((item: TValue) => boolean)): boolean {
+    public remove(item: TValue): boolean {
         throwError(this.readonlyExceptionMessage);
         return undefined;
     }

--- a/src/Collections/List.ts
+++ b/src/Collections/List.ts
@@ -331,13 +331,17 @@ export class ObservableList<T> implements wx.IObservableList<T>, Rx.IDisposable,
         return this.inner.indexOf(item) !== -1;
     }
 
-    public remove(item: T): boolean {
-        let index = this.inner.indexOf(item);
-        if (index === -1)
-            return false;
-
-        this.removeItem(index);
-        return true;
+    public remove(itemOrSelector: T | ((item: T) => boolean)): boolean {
+        const selector =<(item: T) => boolean> ((typeof itemOrSelector === "function") ? itemOrSelector : item => item === itemOrSelector);
+        let itemsRemoved = false;
+        for (let index = 0; index < this.inner.length; index++) {
+            if (selector(this.inner[index])) {
+                itemsRemoved = true;
+                this.removeItem(index);
+                index--;
+            }
+        }
+        return itemsRemoved;
     }
 
     public indexOf(item: T): number {
@@ -796,7 +800,7 @@ class ObservableListProjection<T, TValue> extends ObservableList<TValue> impleme
         throwError(this.readonlyExceptionMessage);
     }
 
-    public remove(item: TValue): boolean {
+    public remove(itemOrSelector: TValue | ((item: TValue) => boolean)): boolean {
         throwError(this.readonlyExceptionMessage);
         return undefined;
     }

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -322,7 +322,7 @@ module wx {
         add(item: T): void;
         push(item: T): void;
         clear(): void;
-        remove(item: T): boolean;
+        remove(itemOrSelector: T | ((item: T) => boolean)): boolean;
         insert(index: number, item: T): void;
         removeAt(index: number): void;
         addRange(collection: Array<T>): void;

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -322,13 +322,13 @@ module wx {
         add(item: T): void;
         push(item: T): void;
         clear(): void;
-        remove(itemOrSelector: T | ((item: T) => boolean)): boolean;
+        remove(item: T): boolean;
         insert(index: number, item: T): void;
         removeAt(index: number): void;
         addRange(collection: Array<T>): void;
         insertRange(index: number, collection: Array<T>): void;
         move(oldIndex: any, newIndex: any): void;
-        removeAll(items: Array<T>): void;
+        removeAll(itemsOrSelector: Array<T> | ((item: T) => boolean)): Array<T>;
         removeRange(index: number, count: number): void;
         reset(contents?: Array<T>): void;
 

--- a/src/web.rx.d.ts
+++ b/src/web.rx.d.ts
@@ -285,7 +285,7 @@ declare module wx {
         add(item: T): void;
         push(item: T): void;
         clear(): void;
-        remove(item: T): boolean;
+        remove(itemOrSelector: T | ((item: T) => boolean)): boolean;
         insert(index: number, item: T): void;
         removeAt(index: number): void;
         addRange(collection: Array<T>): void;

--- a/src/web.rx.d.ts
+++ b/src/web.rx.d.ts
@@ -285,13 +285,13 @@ declare module wx {
         add(item: T): void;
         push(item: T): void;
         clear(): void;
-        remove(itemOrSelector: T | ((item: T) => boolean)): boolean;
+        remove(item: T): boolean;
         insert(index: number, item: T): void;
         removeAt(index: number): void;
         addRange(collection: Array<T>): void;
         insertRange(index: number, collection: Array<T>): void;
         move(oldIndex: any, newIndex: any): void;
-        removeAll(items: Array<T>): void;
+        removeAll(itemsOrSelector: Array<T> | ((item: T) => boolean)): Array<T>;
         removeRange(index: number, count: number): void;
         reset(contents?: Array<T>): void;
 

--- a/test/Collections/List.ts
+++ b/test/Collections/List.ts
@@ -705,7 +705,7 @@ describe("Projected Observable List", () => {
         expect(1).toEqual(disposed.length);
     });
 
-    it("should remove items that satisfy the given selector", () => {
+    it("should remove all items that satisfy the given selector", () => {
         var input = [1, 2, 3, 4];
         var disposed = new Array<number>();
 
@@ -715,7 +715,7 @@ describe("Projected Observable List", () => {
             x.items.forEach(item => disposed.push(item));
         });
 
-        fixture.remove(x => x % 2 == 0);
+        fixture.removeAll(x => x % 2 == 0);
 
         expect(2).toEqual(disposed.length);
         expect(2).toEqual(disposed[0]);

--- a/test/Collections/List.ts
+++ b/test/Collections/List.ts
@@ -705,6 +705,23 @@ describe("Projected Observable List", () => {
         expect(1).toEqual(disposed.length);
     });
 
+    it("should remove items that satisfy the given selector", () => {
+        var input = [1, 2, 3, 4];
+        var disposed = new Array<number>();
+
+        var fixture = wx.list<number>(input);
+
+        fixture.itemsRemoved.subscribe(x => {
+            x.items.forEach(item => disposed.push(item));
+        });
+
+        fixture.remove(x => x % 2 == 0);
+
+        expect(2).toEqual(disposed.length);
+        expect(2).toEqual(disposed[0]);
+        expect(4).toEqual(disposed[1]);
+    });
+
     it("addRange smoke-test", () => {
         var fixture = wx.list<string>();
         var output = fixture.project(undefined, undefined, x => "Prefix" + x);


### PR DESCRIPTION
I changed remove function of observable lists, so it can also use a selector, in addition to current behavior.
```typescript
const list = wx.list([1,2,3,4]);
list.remove(x => x > 2);
```