### PR TITLE
Feature/dynamic invokecommand

### DIFF
--- a/src/RxExtensions.d.ts
+++ b/src/RxExtensions.d.ts
@@ -9,6 +9,7 @@ declare module Rx {
         continueWith<TOther>(obs: Rx.Observable<TOther>): Observable<TOther>;
 
         invokeCommand<TResult>(command: wx.ICommand<TResult>): Rx.IDisposable;
+        invokeCommand<TResult>(commandSelector: () => wx.ICommand<TResult>): Rx.IDisposable;
     }
 
     export interface ObservableStatic {

--- a/src/RxExtensions.ts
+++ b/src/RxExtensions.ts
@@ -100,15 +100,19 @@ RxObsConstructor.prototype.continueWith = function() {
     return this.selectMany(_ => obs);
 }
 
-RxObsConstructor.prototype.invokeCommand = <T, TResult>(command: wx.ICommand<TResult>) => {
+RxObsConstructor.prototype.invokeCommand = <T, TResult>(command: () => wx.ICommand<TResult> | wx.ICommand<TResult>) => {
     // see the ReactiveUI project for the inspiration behind this function:
     // https://github.com/reactiveui/ReactiveUI/blob/master/ReactiveUI/ReactiveCommand.cs#L511
     return (this as Rx.Observable<T>)
+        .select(x => ({ 
+            parameter: x, 
+            command: (command instanceof Function ? command() : command) as wx.ICommand<TResult>
+        }))
         // debounce typings want the (incorrectly named) durationSelector to return a number here
         // this is why there is a .select(x => 0) at the end
         // the 0 doesn't get used, as the debounce occurs on the observable not the values it produces
-        .debounce(x => command.canExecuteObservable.startWith(command.canExecute(x)).where(b => b).select(x => 0))
-        .select(x => command.executeAsync(x).catch(Rx.Observable.empty<TResult>()))
+        .debounce(x => x.command.canExecuteObservable.startWith(x.command.canExecute(x.parameter)).where(b => b).select(x => 0))
+        .select(x => x.command.executeAsync(x.parameter).catch(Rx.Observable.empty<TResult>()))
         .switch()
         .subscribe();
 }

--- a/src/RxExtensions.ts
+++ b/src/RxExtensions.ts
@@ -100,7 +100,7 @@ RxObsConstructor.prototype.continueWith = function() {
     return this.selectMany(_ => obs);
 }
 
-RxObsConstructor.prototype.invokeCommand = <T, TResult>(command: () => wx.ICommand<TResult> | wx.ICommand<TResult>) => {
+function invokeCommand<T, TResult>(command: () => wx.ICommand<TResult> | wx.ICommand<TResult>) {
     // see the ReactiveUI project for the inspiration behind this function:
     // https://github.com/reactiveui/ReactiveUI/blob/master/ReactiveUI/ReactiveCommand.cs#L511
     return (this as Rx.Observable<T>)
@@ -116,6 +116,8 @@ RxObsConstructor.prototype.invokeCommand = <T, TResult>(command: () => wx.IComma
         .switch()
         .subscribe();
 }
+
+RxObsConstructor.prototype.invokeCommand = invokeCommand;
 
 RxObsConstructor.startDeferred = <T>(action: () => T): Rx.Observable<T> => {
     return Rx.Observable.defer(() => {

--- a/src/RxExtensions.ts
+++ b/src/RxExtensions.ts
@@ -101,16 +101,16 @@ RxObsConstructor.prototype.continueWith = function() {
 }
 
 RxObsConstructor.prototype.invokeCommand = <T, TResult>(command: wx.ICommand<TResult>) => {
-  // see the ReactiveUI project for the inspiration behind this function:
-  // https://github.com/reactiveui/ReactiveUI/blob/master/ReactiveUI/ReactiveCommand.cs#L511
-  return (this as Rx.Observable<T>)
-      // debounce typings want the (incorrectly named) durationSelector to return a number here
-      // this is why there is a .select(x => 0) at the end
-      // the 0 doesn't get used, as the debounce occurs on the observable not the values it produces
-      .debounce(x => command.canExecuteObservable.startWith(command.canExecute(x)).where(b => b).select(x => 0))
-      .select(x => command.executeAsync(x).catch(Rx.Observable.empty<TResult>()))
-      .switch()
-      .subscribe();
+    // see the ReactiveUI project for the inspiration behind this function:
+    // https://github.com/reactiveui/ReactiveUI/blob/master/ReactiveUI/ReactiveCommand.cs#L511
+    return (this as Rx.Observable<T>)
+        // debounce typings want the (incorrectly named) durationSelector to return a number here
+        // this is why there is a .select(x => 0) at the end
+        // the 0 doesn't get used, as the debounce occurs on the observable not the values it produces
+        .debounce(x => command.canExecuteObservable.startWith(command.canExecute(x)).where(b => b).select(x => 0))
+        .select(x => command.executeAsync(x).catch(Rx.Observable.empty<TResult>()))
+        .switch()
+        .subscribe();
 }
 
 RxObsConstructor.startDeferred = <T>(action: () => T): Rx.Observable<T> => {


### PR DESCRIPTION
The purpose of this update is to allow dynamic selection of commands to invoke based on an observable stream.

Currently, invokeCommand can only statically invoke a command. That is to say, the command that will be invoked is statically set when the observable stream is constructed. An example will make this very clear.

```typescript
// NOTE: this is a dumb thing to do but it explains the scenario
let flag = wx.property(false);
let trueCmd = wx.command();
let falseCmd = wx.command();

flag.changed.invokeCommand(flag() ? trueCmd : falseCmd);
flag(true);
flag(false);
```

What it looks like will happen is we will invoke the true command, then the false command. What will really happen is we will invoke the true command twice. This is because the command itself is compiled into the observable stream (this is because invokeCommand is evaluated at creation not at each observable value.

What we really want is a function delegate to select the command dynamically within the stream. This PR will allow you to change the invoke line to `.invokeCommand(() => flag() ? trueCmd : falseCmd)` (which is still a dumb thing to do but it makes it clear what this solves). Now each call to invokeCommand (driven by the observable stream) will resolve the command to execute inside the stream.

This is very similar to the [ReactiveUI Implementation](https://github.com/reactiveui/ReactiveUI/blob/master/ReactiveUI/ReactiveCommand.cs#L549) except that it does not include a target (which isn't really necessary).