### PR TITLE
Decoupling WebRx from window and document variables

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -44,10 +44,12 @@ class App extends Module implements wx.IWebRxApp {
     constructor() {
         super("app");
 
-        if (!isInUnitTest()) {
-            this.history = this.createHistory();
-        } else {
-            this.history = <wx.IHistory> window["createMockHistory"]();
+        if (window) {
+            if (!isInUnitTest()) {
+                this.history = this.createHistory();
+            } else {
+                this.history = <wx.IHistory> window["createMockHistory"]();
+            }
         }
     }
 
@@ -110,7 +112,7 @@ class App extends Module implements wx.IWebRxApp {
     }
 
     public history: wx.IHistory;
-    public title: wx.IObservableProperty<string> = property<string>(document.title);
+    public title: wx.IObservableProperty<string> = property<string>(document != null ? document.title : '');
     public version = version;
 
     ///////////////////////

--- a/src/App.ts
+++ b/src/App.ts
@@ -129,8 +129,6 @@ class App extends Module implements wx.IWebRxApp {
             back: window.history.back.bind(window.history),
             forward: window.history.forward.bind(window.history),
             //go: window.history.go,
-            pushState: window.history.pushState.bind(window.history),
-            replaceState: window.history.replaceState.bind(window.history),
 
             getSearchParameters: (query?:string)=> {
                 query = query || result.location.search.substr(1);
@@ -149,6 +147,14 @@ class App extends Module implements wx.IWebRxApp {
                 return {};
             }
         };
+
+        if (window.history.pushState) {
+            result.pushState = window.history.pushState.bind(window.history);
+        }
+
+        if (window.history.replaceState) {
+            result.replaceState = window.history.pushState.bind(window.history);
+        }
 
         Object.defineProperty(result, "length", {
             get() {

--- a/src/Collections/Map.ts
+++ b/src/Collections/Map.ts
@@ -100,9 +100,9 @@ function isFunction(o: any): boolean {
     return typeof o === 'function';
 }
 
-var proto: wx.IMap<any, any> = window["Map"] !== undefined ? <any> Map.prototype : undefined;
+var proto: wx.IMap<any, any> = (window != null && window["Map"] !== undefined) ? <any> Map.prototype : undefined;
 
-var hasNativeSupport = isFunction(window["Map"]) && isFunction(proto.forEach) &&
+var hasNativeSupport = window != null && isFunction(window["Map"]) && isFunction(proto.forEach) &&
     isFunction(proto.set) && isFunction(proto.clear) &&
     isFunction(proto.delete) && isFunction(proto.has);
 

--- a/src/Collections/Set.ts
+++ b/src/Collections/Set.ts
@@ -71,9 +71,9 @@ function isFunction(o: any): boolean {
     return typeof o === 'function';
 }
 
-var proto: wx.ISet<any> = window["Set"] !== undefined ? <any> Set.prototype : undefined;
+var proto: wx.ISet<any> = (window != null && window["Set"] !== undefined) ? <any> Set.prototype : undefined;
 
-var hasNativeSupport = isFunction(window["Set"]) && isFunction(proto.forEach) &&
+var hasNativeSupport = window != null && isFunction(window["Set"]) && isFunction(proto.forEach) &&
     isFunction(proto.add) && isFunction(proto.clear) &&
     isFunction(proto.delete) && isFunction(proto.has);
 

--- a/src/Collections/WeakMap.ts
+++ b/src/Collections/WeakMap.ts
@@ -49,9 +49,9 @@ function isFunction(o: any): boolean {
     return typeof o === 'function';
 }
 
-var proto: wx.IWeakMap<any, any> = window["WeakMap"] !== undefined ? <any> WeakMap.prototype : undefined;
+var proto: wx.IWeakMap<any, any> = (window != null && window["WeakMap"] !== undefined) ? <any> WeakMap.prototype : undefined;
 
-var hasNativeSupport = isFunction(window["WeakMap"]) &&
+var hasNativeSupport = window != null && isFunction(window["WeakMap"]) &&
     isFunction(proto.set) && isFunction(proto.get) &&
     isFunction(proto.delete) && isFunction(proto.has);
 

--- a/src/Core/DomManager.ts
+++ b/src/Core/DomManager.ts
@@ -677,7 +677,7 @@ export class DomManager implements wx.IDomManager {
 * @param {Node} rootNode The node to be bound
 */
 export function applyBindings(model: any, node?: Node) {
-    injector.get<wx.IDomManager>(res.domManager).applyBindings(model, node || window.document.documentElement);
+    injector.get<wx.IDomManager>(res.domManager).applyBindings(model, node || (window != null ? window.document.documentElement : null));
 }
 /**
 * Removes and cleans up any binding-related state from the specified node and its descendants.

--- a/src/Core/Environment.ts
+++ b/src/Core/Environment.ts
@@ -3,7 +3,7 @@
 "use strict";
 
 let _window = <any> window;
-let userAgent = _window.navigator.userAgent;
+let userAgent = _window != null ? _window.navigator.userAgent : null;
 
 export var ie: wx.IIEBrowserProperties;
 export var opera: wx.IBrowserProperties;
@@ -19,7 +19,7 @@ let parseVersion = matches => {
 }
 
 // Detect Opera
-if (_window.opera && _window.opera.version) {
+if (_window != null && _window.opera && _window.opera.version) {
     opera = { version: parseInt(_window.opera.version()) };
 }
 
@@ -91,7 +91,7 @@ export var isSupported = (!ie || ie.version >= 9) ||
     hasES5;
 
 // Special support for jQuery here because it's so commonly used.
-export var jQueryInstance = window["jQuery"];
+export var jQueryInstance = window != null ? window["jQuery"] : null;
 
 /**
 * Strips any external data associated with the node from it

--- a/src/Core/Module.ts
+++ b/src/Core/Module.ts
@@ -244,8 +244,9 @@ export class Module implements wx.IModule {
                 return observableRequire<string>(options.require).select(x => this.app.templateEngine.parse(x));
             } else if (options.select) {
                 // try both getElementById & querySelector
-                el = document.getElementById(<string> options.select) ||
-                    document.querySelector(<string> options.select);
+                el = document != null ? (
+                    document.getElementById(<string> options.select) ||
+                    document.querySelector(<string> options.select)) : null;
 
                 if (el != null) {
                     // only the nodes inside the specified element will be cloned for use as the component’s template

--- a/src/Core/Utils.ts
+++ b/src/Core/Utils.ts
@@ -469,7 +469,7 @@ declare function require(modules: string[], successCB: (any) => any, errCB: (err
 * @return {Rx.Observable<any>} An observable that yields a value and completes as soon as the module has been loaded
 */
 export function observableRequire<T>(module: string): Rx.Observable<T> {
-    var requireFunc = window["require"];
+    var requireFunc = window != null ? window["require"] : null;
 
     if (!isFunction(requireFunc))
         throwError("there's no AMD-module loader available (Hint: did you forget to include RequireJS in your project?)");

--- a/src/Routing/Router.ts
+++ b/src/Routing/Router.ts
@@ -49,14 +49,15 @@ export class Router implements wx.IRouter {
             }
         });
 
+        if (document) {
+            // monitor title changes
+            app.title.changed.subscribe(x => {
+                document.title = x;
 
-        // monitor title changes
-        app.title.changed.subscribe(x => {
-            document.title = x;
-
-            if(this.current() != null)
-                this.replaceHistoryState(this.current(), x);
-        });
+                if(this.current() != null)
+                    this.replaceHistoryState(this.current(), x);
+            });
+        }
     }
 
     //////////////////////////////////
@@ -292,7 +293,7 @@ export class Router implements wx.IRouter {
         let hs = <IHistoryState> {
             stateName: state.name,
             params: state.params,
-            title: title != null ? title : document.title
+            title: title != null ? title : document != null ? document.title : ''
         };
 
         this.app.history.pushState(hs, "", state.url);
@@ -302,7 +303,7 @@ export class Router implements wx.IRouter {
         let hs = <IHistoryState> {
             stateName: state.name,
             params: state.params,
-            title: title != null ? title : document.title
+            title: title != null ? title : document != null ? document.title : ''
         };
 
         this.app.history.replaceState(hs, "", state.url);


### PR DESCRIPTION
WebRx currently makes some assumptions on the availability and structure of the `window` and `document` global variables. This prevents certain types setups (such as a test harness for example) from using WebRx. This patch transforms the usage of these variables into ternary statements to prevent a hard crash when the variable is undefined or a member within the structure is missing.

Additionally this patches an issue with IE9 where `pushState` and `replaceState` functions are expected to exist on `window.history` but are not available. This means that any usage of these will fail under IE9, so it's a bit unclear if a polyfill should be created here as well. At the very least we want to avoid hard crashing the entire app.