### PR TITLE
WebRx Lite

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -286,7 +286,7 @@ module.exports = function (grunt) {
     grunt.registerTask("test-lite", ["trimtrailingspaces", "shell:tsc_src_es5", "madge:src", "webpack:webrxlite", "shell:tsc_specs", "jasmine:lite"]);
     grunt.registerTask("debug", ["trimtrailingspaces", "shell:tsc_src_es5", "madge:src", "webpack:webrx", "shell:tsc_specs", "jasmine:default:build", "connect", "watch"]);
     grunt.registerTask("debug-lite", ["trimtrailingspaces", "shell:tsc_src_es5", "madge:src", "webpack:webrxlite", "shell:tsc_specs", "jasmine:lite:build", "connect", "watch"]);
-    grunt.registerTask("build-dist", ["gen-ver", "trimtrailingspaces", "clean:build", "shell:tsc_src_es5", "shell:tsc_src_es6", "madge:src", "webpack:webrx", "clean:dist", "copy:dist", "uglify:dist", "compress:dist"]);
+    grunt.registerTask("build-dist", ["gen-ver", "trimtrailingspaces", "clean:build", "shell:tsc_src_es5", "shell:tsc_src_es6", "madge:src", "webpack:webrx", "webpack:webrxlite", "clean:dist", "copy:dist", "uglify:dist", "compress:dist"]);
     grunt.registerTask("dist", ["build-dist", "shell:tsc_specs", "jasmine:dist"]);
     grunt.registerTask("xtest", ["gen-ver", "trimtrailingspaces", "shell:tsc_src_es5", "shell:tsc_specs", "jasmine:default:build", "connect", "saucelabs-jasmine"]);
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -236,6 +236,10 @@ module.exports = function (grunt) {
     //var webpack = require("webpack");
     var _ = require("lodash");
 
+    conf.webpack["webrxlite"] = _.cloneDeep(conf.webpack.webrx);
+    conf.webpack.webrxlite.entry = './build/src/es5/WebRx.Lite.js';
+    conf.webpack.webrxlite.output.filename = 'web.rx.lite.js';
+
     conf.jasmine["dist"] = _.cloneDeep(conf.jasmine.default);
     conf.jasmine.dist.options.vendor[9] = 'dist/web.rx.min.js';
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -147,7 +147,7 @@ module.exports = function (grunt) {
         copy: {
             dist: {
                 files: [
-                    { expand: true, cwd: 'build/', src: ['web.rx.js*'], dest: 'dist/' },
+                    { expand: true, cwd: 'build/', src: ['web.rx.js*', 'web.rx.lite.js*'], dest: 'dist/' },
                     { expand: true, cwd: 'build/src/es6', src: ['**'], dest: 'dist/es6_modules' },
                     { expand: true, cwd: 'src/', src: ['web.rx.d.ts'], dest: 'dist/' },
                 ],
@@ -165,20 +165,21 @@ module.exports = function (grunt) {
                     archive: 'dist/web.rx.zip'
                 },
                 files: [
-                    { expand: true, cwd: "dist/", src: ['web.rx.js', 'web.rx.js.map', 'web.rx.min.js', 'web.rx.min.js.map', 'web.rx.d.ts', "es6_modules/**"] }
+                    { expand: true, cwd: "dist/", src: ['web.rx.js', 'web.rx.js.map', 'web.rx.min.js', 'web.rx.min.js.map', 'web.rx.lite.js', 'web.rx.lite.js.map', 'web.rx.lite.min.js', 'web.rx.lite.min.js.map', 'web.rx.d.ts', "es6_modules/**"] }
                 ]
             }
         },
         uglify: {
             dist: {
                 files: {
-                    'dist/web.rx.min.js': ['dist/web.rx.js']
+                    'dist/web.rx.min.js': ['dist/web.rx.js'],
+                    'dist/web.rx.lite.min.js': ['dist/web.rx.lite.js']
                 },
                 
                 options: {
                     sourceMap: true,
                     sourceMapIncludeSources: true,
-                    sourceMapIn: "dist/web.rx.js.map"
+                    sourceMapIn: function(path) { return path + '.map'; }
                 }
             }
         },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -81,7 +81,7 @@ module.exports = function (grunt) {
         watch: {
             src: {
                 files: ["src/**/*.ts"],
-                tasks: ['shell:tsc_src_es5', "madge:src", "webpack:webrx"]
+                tasks: ['shell:tsc_src_es5', "madge:src", "webpack:webrx", "webpack:webrxlite"]
             },
             specs: {
                 files: ["test/**/*.ts", "!test/typings/*.ts"],
@@ -285,6 +285,7 @@ module.exports = function (grunt) {
     grunt.registerTask("test", ["trimtrailingspaces", "shell:tsc_src_es5", "madge:src", "webpack:webrx", "shell:tsc_specs", "jasmine:default"]);
     grunt.registerTask("test-lite", ["trimtrailingspaces", "shell:tsc_src_es5", "madge:src", "webpack:webrxlite", "shell:tsc_specs", "jasmine:lite"]);
     grunt.registerTask("debug", ["trimtrailingspaces", "shell:tsc_src_es5", "madge:src", "webpack:webrx", "shell:tsc_specs", "jasmine:default:build", "connect", "watch"]);
+    grunt.registerTask("debug-lite", ["trimtrailingspaces", "shell:tsc_src_es5", "madge:src", "webpack:webrxlite", "shell:tsc_specs", "jasmine:lite:build", "connect", "watch"]);
     grunt.registerTask("build-dist", ["gen-ver", "trimtrailingspaces", "clean:build", "shell:tsc_src_es5", "shell:tsc_src_es6", "madge:src", "webpack:webrx", "clean:dist", "copy:dist", "uglify:dist", "compress:dist"]);
     grunt.registerTask("dist", ["build-dist", "shell:tsc_specs", "jasmine:dist"]);
     grunt.registerTask("xtest", ["gen-ver", "trimtrailingspaces", "shell:tsc_src_es5", "shell:tsc_specs", "jasmine:default:build", "connect", "saucelabs-jasmine"]);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -244,6 +244,18 @@ module.exports = function (grunt) {
     conf.jasmine["dist"] = _.cloneDeep(conf.jasmine.default);
     conf.jasmine.dist.options.vendor[9] = 'dist/web.rx.min.js';
 
+    conf.jasmine["lite"] = _.cloneDeep(conf.jasmine.default);
+    conf.jasmine.lite.options.vendor[10] = 'build/web.rx.lite.js';
+    conf.jasmine.lite.options.specs = [
+      'build/test/*.js',
+      'build/test/Collections/**/*.js',
+      'build/test/Core/**/*.js',
+      '!build/test/Core/VirtualChildNodes.js',
+      '!build/test/Core/DomManager.js',
+      '!build/test/Core/ExpressionCompiler.js',
+      '!build/test/Core/HtmlTemplateEngine.js',
+    ];
+
     grunt.initConfig(conf);
 
     grunt.loadNpmTasks('grunt-contrib-jasmine');

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -283,6 +283,7 @@ module.exports = function (grunt) {
 
     grunt.registerTask("default", ["clean:build", "trimtrailingspaces", "shell:tsc_src_es5"]);
     grunt.registerTask("test", ["trimtrailingspaces", "shell:tsc_src_es5", "madge:src", "webpack:webrx", "shell:tsc_specs", "jasmine:default"]);
+    grunt.registerTask("test-lite", ["trimtrailingspaces", "shell:tsc_src_es5", "madge:src", "webpack:webrxlite", "shell:tsc_specs", "jasmine:lite"]);
     grunt.registerTask("debug", ["trimtrailingspaces", "shell:tsc_src_es5", "madge:src", "webpack:webrx", "shell:tsc_specs", "jasmine:default:build", "connect", "watch"]);
     grunt.registerTask("build-dist", ["gen-ver", "trimtrailingspaces", "clean:build", "shell:tsc_src_es5", "shell:tsc_src_es6", "madge:src", "webpack:webrx", "clean:dist", "copy:dist", "uglify:dist", "compress:dist"]);
     grunt.registerTask("dist", ["build-dist", "shell:tsc_specs", "jasmine:dist"]);

--- a/src/WebRx.Lite.ts
+++ b/src/WebRx.Lite.ts
@@ -1,0 +1,41 @@
+/// <reference path="./Interfaces.ts" />
+
+// WebRx Lite API-Surface (No UI functionality is included)
+export * from "./Core/Utils";
+export { property } from "./Core/Property";
+export { command, asyncCommand, isCommand } from "./Core/Command";
+export { getOid } from "./Core/Oid";
+export { list } from "./Collections/List";
+export { isList } from "./Collections/ListSupport";
+export { createMap } from "./Collections/Map";
+export { createSet, setToArray } from "./Collections/Set";
+export { createWeakMap } from "./Collections/WeakMap";
+export { default as Lazy } from "./Core/Lazy";
+import { injector } from "./Core/Injector";
+export { injector };
+export { default as IID } from "./IID";
+export { getHttpClientDefaultConfig } from "./Core/HttpClient";
+
+import * as res from "./Core/Resources";
+export { res };
+
+// install the Rx extensions manually (instead of in App which is not exported)
+import { install } from "./RxExtensions"
+install();
+
+import MessageBus from "./Core/MessageBus"
+import HttpClient from "./Core/HttpClient"
+
+// simulate a minimal App component
+export var app = <wx.IWebRxApp>{
+  defaultExceptionHandler: Rx.Observer.create<Error>(ex => {}),
+  mainThreadScheduler: this._unitTestMainThreadScheduler || this._mainThreadScheduler || Rx.Scheduler.currentThread
+};
+
+// register the app, messageBus, and httpClient instances
+injector.register(res.app, app)
+  .register(res.messageBus, [MessageBus], true)
+  .register(res.httpClient, [HttpClient], false);
+
+// manually export the messageBus (instead of in App which is not exported)
+export var messageBus = injector.get<wx.IMessageBus>(res.messageBus);

--- a/test/Collections/List.ts
+++ b/test/Collections/List.ts
@@ -1223,31 +1223,33 @@ function pagedTestImpl(fixturePostfix: string, isProjected: boolean, sourceTrans
             expect(eReplaced.from).toEqual(9);
         });
 
-        it("itemsMoved forEach-Binding edge-case test", () => {
-            loadFixtures('templates/Bindings/ForEach.html');
+        if (wx.applyBindings) {
+            it("itemsMoved forEach-Binding edge-case test", () => {
+                loadFixtures('templates/Bindings/ForEach.html');
 
-            let source = wx.list<number>();
-            source.addRange(Ix.Enumerable.range(1, 30).toArray());
+                let source = wx.list<number>();
+                source.addRange(Ix.Enumerable.range(1, 30).toArray());
 
-            let paged = sourceTransformer(source).page(10, 1);
+                let paged = sourceTransformer(source).page(10, 1);
 
-            const el = <HTMLElement> document.getElementById("foreach-list-scalar");
-            expect(() => wx.applyBindings({ src: paged }, el)).not.toThrowError();
+                const el = <HTMLElement> document.getElementById("foreach-list-scalar");
+                expect(() => wx.applyBindings({ src: paged }, el)).not.toThrowError();
 
-            expect($(el).children().map((index, node) => parseInt(node.textContent)).get()).toEqual(paged.toArray());
+                expect($(el).children().map((index, node) => parseInt(node.textContent)).get()).toEqual(paged.toArray());
 
-            // a move with both from- and and to-index inside it should result in a move
-            source.move(17, 19);
-            expect($(el).children().map((index, node) => parseInt(node.textContent)).get()).toEqual(paged.toArray());
+                // a move with both from- and and to-index inside it should result in a move
+                source.move(17, 19);
+                expect($(el).children().map((index, node) => parseInt(node.textContent)).get()).toEqual(paged.toArray());
 
-            // a move with a from-index inside the window and to-index below it should result in a remove followed by replace
-            source.move(17, 25);
-            expect($(el).children().map((index, node) => parseInt(node.textContent)).get()).toEqual(paged.toArray());
+                // a move with a from-index inside the window and to-index below it should result in a remove followed by replace
+                source.move(17, 25);
+                expect($(el).children().map((index, node) => parseInt(node.textContent)).get()).toEqual(paged.toArray());
 
-            // a move with a from-index at the bottom of the window and to-index below it should result in a replace for the last item
-            source.move(19, 25);
-            expect($(el).children().map((index, node) => parseInt(node.textContent)).get()).toEqual(paged.toArray());
-        });
+                // a move with a from-index at the bottom of the window and to-index below it should result in a replace for the last item
+                source.move(19, 25);
+                expect($(el).children().map((index, node) => parseInt(node.textContent)).get()).toEqual(paged.toArray());
+            });
+        }
     });
 }
 


### PR DESCRIPTION
@oliverw we had somewhat discussed this a while back (either on gitter or here on github) about building a more modular WebRx so that consumers like me who don't use the UI parts don't need to load the entire bundle.

I decided to take a stab at it tonight to see what I could come up with. My goal was to have minimal invasive changes but still achieve the ultimate goal of minimizing the bundle. My strategy shifted from modular to simply projection.

This PR primarily focuses on patching the `Gruntfile.js` to support a `Lite` build, which is produced by creating a **new** *API Surface* (`WebRx.Lite.ts`) that only exports the core (*non-UI*) functionality. The result is that we have just created an additional bundle as a part of the build process which leaves the rest of the WebRx infrastructure in tact and unchanged.

I had to make a small invasive change to the `Collections` test specs because one test was performing some binding operation (I noted in the commit message that perhaps that test better belongs in the `Bindings` specs). Otherwise all (*non-UI*) tests still pass.

I have yet to fully test this out with my existing work (this may happen in the next few days) but I suspect it should work without issue.

Please let me know if you have any thoughts on this, would be great to get it into the next version.