### PR TITLE
Updating toProperty() to support better error handling

### DIFF
--- a/src/IID.ts
+++ b/src/IID.ts
@@ -6,6 +6,7 @@
 export default class IID {
     static IDisposable = "IDisposable";
     static IObservableProperty = "IObservableProperty";
+    static IObservableReadOnlyProperty = "IObservableReadOnlyProperty";
     static IObservableList = "IObservableList";
     static ICommand = "ICommand";
     static IHandleObservableErrors = "IHandleObservableErrors";

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -81,6 +81,18 @@ module wx {
         source?: Rx.Observable<T>;
     }
 
+    /**
+    * IObservableReadOnlyProperty provides observable source and thrownExceptions
+    * members with the standard observable property base members
+    * @interface
+    **/
+    export interface IObservableReadOnlyProperty<T> extends IObservableProperty<T> {
+      source: Rx.Observable<T>;
+      thrownExceptions: Rx.Observable<Error>;
+
+      catchExceptions(onError: (error: Error) => void): IObservableReadOnlyProperty<T>;
+    }
+
     export interface IRangeInfo {
         from: number;
         to?: number;

--- a/src/RxExtensions.d.ts
+++ b/src/RxExtensions.d.ts
@@ -2,7 +2,7 @@
 
 declare module Rx {
     export interface Observable<T> extends IObservable<T> {
-        toProperty(initialValue?: T): wx.IObservableProperty<T>;
+        toProperty(initialValue?: T): wx.IObservableReadOnlyProperty<T>;
 
         continueWith(action: () => void): Observable<any>;
         continueWith<TResult>(action: (T) => TResult): Observable<TResult>;

--- a/src/RxExtensions.ts
+++ b/src/RxExtensions.ts
@@ -31,7 +31,7 @@ function toProperty(initialValue?: any, scheduler?: Rx.IScheduler) {
     // wx.IUnknown implementation
 
     accessor.queryInterface = (iid: string)=> {
-       return iid === IID.IObservableProperty || iid === IID.IDisposable;
+       return iid === IID.IObservableReadOnlyProperty || IID.IObservableProperty || iid === IID.IDisposable;
     }
 
     //////////////////////////////////
@@ -45,7 +45,7 @@ function toProperty(initialValue?: any, scheduler?: Rx.IScheduler) {
     };
 
     //////////////////////////////////
-    // IObservableProperty<T> implementation
+    // IObservableReadOnlyProperty<T> implementation
 
     accessor.value = initialValue;
 
@@ -58,6 +58,14 @@ function toProperty(initialValue?: any, scheduler?: Rx.IScheduler) {
 
     accessor.source = this;
     accessor.thrownExceptions = createScheduledSubject<Error>(scheduler, injector.get<wx.IWebRxApp>(res.app).defaultExceptionHandler);
+
+    accessor.catchExceptions = (onError: (error: Error) => void) => {
+      accessor.thrownExceptions.subscribe((e: Error) => {
+        onError(e);
+      });
+
+      return accessor;
+    };
 
     //////////////////////////////////
     // implementation

--- a/src/web.rx.d.ts
+++ b/src/web.rx.d.ts
@@ -1571,6 +1571,6 @@ declare module wx {
 
 declare module Rx {
     export interface Observable<T> extends IObservable<T> {
-        toProperty(initialValue?: T): wx.IObservableProperty<T>;
+        toProperty(initialValue?: T): wx.IObservableReadOnlyProperty<T>;
     }
 }

--- a/src/web.rx.d.ts
+++ b/src/web.rx.d.ts
@@ -51,6 +51,7 @@ declare module wx {
         size: number;
         isEmulated: boolean;
     }
+
     /**
     /* IObservableProperty combines a function signature for value setting and getting with
     /* observables for monitoring value changes
@@ -62,6 +63,18 @@ declare module wx {
         changing: Rx.Observable<T>;
         changed: Rx.Observable<T>;
         source?: Rx.Observable<T>;
+    }
+
+    /**
+    * IObservableReadOnlyProperty provides observable source and exception
+    * handling members with the standard observable property members
+    * @interface
+    **/
+    interface IObservableReadOnlyProperty<T> extends IObservableProperty<T> {
+      source: Rx.Observable<T>;
+      thrownExceptions: Rx.Observable<Error>;
+
+      catchExceptions(onError: (error: Error) => void): IObservableReadOnlyProperty<T>;
     }
 
     export interface IRangeInfo {
@@ -1033,6 +1046,7 @@ declare module wx {
     class IID {
         static IDisposable: string;
         static IObservableProperty: string;
+        static IObservableReadOnlyProperty: string;
         static IObservableList: string;
         static ICommand: string;
         static IHandleObservableErrors: string;

--- a/test/Core/PropertyComputed.ts
+++ b/test/Core/PropertyComputed.ts
@@ -14,6 +14,11 @@ describe("Output Properties", () => {
         expect(wx.queryInterface(prop, wx.IID.IObservableProperty)).toBeTruthy();
     });
 
+    it("implements IObservableReadOnlyProperty",() => {
+        let prop = Rx.Observable.never().toProperty();
+        expect(wx.queryInterface(prop, wx.IID.IObservableReadOnlyProperty)).toBeTruthy();
+    });
+
     it("observables are set up during creation",() => {
         let prop = Rx.Observable.never().toProperty();
         expect(prop.changing !== undefined && prop.changed !== undefined).toBeTruthy();
@@ -128,5 +133,26 @@ describe("Output Properties", () => {
         subject.onNext(2);
 
         expect(changedFiredCount).toEqual(2);
+    });
+
+    it("captures errors in the observable source", () => {
+        let subject = new Rx.Subject<number>();
+        let prop = subject.toProperty();
+        let errorCount = 0;
+
+        prop.thrownExceptions.subscribe(x => errorCount++);
+        subject.onError('error');
+
+        expect(errorCount).toEqual(1);
+    });
+
+    it("allows connecting an error handler at construction", () => {
+        let subject = new Rx.Subject<number>();
+        let errorCount = 0;
+        let prop = subject.toProperty().catchExceptions(x => errorCount++);
+
+        subject.onError('error');
+
+        expect(errorCount).toEqual(1);
     });
 });


### PR DESCRIPTION
I'm adding a new interface that extends `IObservableProperty<T>` that is better suited for use with output properties. Now these output properties expose the `thrownExceptions` member, but additionally allow error handling at construction via the `catchExceptions(...)` function that is added in this PR.

I also overrided the `source` member on the new interface, so that it is no longer optional. I tried to remove the `source` from the base but there are too many pieces of code that rely on it being on the interface. Perhaps down the road we could remove it?

Also added some test for this new functionality.

fixes #36 