### PR TITLE
patching invokeCommand

### DIFF
--- a/src/RxExtensions.d.ts
+++ b/src/RxExtensions.d.ts
@@ -9,7 +9,7 @@ declare module Rx {
         continueWith<TOther>(obs: Rx.Observable<TOther>): Observable<TOther>;
 
         invokeCommand<TResult>(command: wx.ICommand<TResult>): Rx.IDisposable;
-        invokeCommand<TResult>(commandSelector: (x: any) => wx.ICommand<TResult>): Rx.IDisposable;
+        invokeCommand<TResult>(commandSelector: (x: T) => wx.ICommand<TResult>): Rx.IDisposable;
     }
 
     export interface ObservableStatic {

--- a/src/RxExtensions.d.ts
+++ b/src/RxExtensions.d.ts
@@ -9,7 +9,7 @@ declare module Rx {
         continueWith<TOther>(obs: Rx.Observable<TOther>): Observable<TOther>;
 
         invokeCommand<TResult>(command: wx.ICommand<TResult>): Rx.IDisposable;
-        invokeCommand<TResult>(commandSelector: () => wx.ICommand<TResult>): Rx.IDisposable;
+        invokeCommand<TResult>(commandSelector: (x: any) => wx.ICommand<TResult>): Rx.IDisposable;
     }
 
     export interface ObservableStatic {

--- a/src/RxExtensions.ts
+++ b/src/RxExtensions.ts
@@ -108,7 +108,7 @@ RxObsConstructor.prototype.continueWith = function() {
     return this.selectMany(_ => obs);
 }
 
-function invokeCommand<T, TResult>(command: () => wx.ICommand<TResult> | wx.ICommand<TResult>) {
+function invokeCommand<T, TResult>(command: (x: T) => wx.ICommand<TResult> | wx.ICommand<TResult>) {
     // see the ReactiveUI project for the inspiration behind this function:
     // https://github.com/reactiveui/ReactiveUI/blob/master/ReactiveUI/ReactiveCommand.cs#L524
     return (this as Rx.Observable<T>)

--- a/src/web.rx.d.ts
+++ b/src/web.rx.d.ts
@@ -1573,6 +1573,6 @@ declare module Rx {
         toProperty(initialValue?: T): wx.IObservableReadOnlyProperty<T>;
         
         invokeCommand<TResult>(command: wx.ICommand<TResult>): Rx.IDisposable;
-        invokeCommand<TResult>(commandSelector: (x: any) => wx.ICommand<TResult>): Rx.IDisposable;
+        invokeCommand<TResult>(commandSelector: (x: T) => wx.ICommand<TResult>): Rx.IDisposable;
     }
 }

--- a/src/web.rx.d.ts
+++ b/src/web.rx.d.ts
@@ -1571,5 +1571,8 @@ declare module wx {
 declare module Rx {
     export interface Observable<T> extends IObservable<T> {
         toProperty(initialValue?: T): wx.IObservableReadOnlyProperty<T>;
+        
+        invokeCommand<TResult>(command: wx.ICommand<TResult>): Rx.IDisposable;
+        invokeCommand<TResult>(commandSelector: (x: any) => wx.ICommand<TResult>): Rx.IDisposable;
     }
 }


### PR DESCRIPTION
support dynamic command selection based on the parameter provided.

I actually thought I had included this in there in the last PR, but I guess it slipped through the cracks.